### PR TITLE
Change SWM logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Add the following line to your `deps` in `mix.exs`.  Run `mix deps.get`.
 
 Copyright 2019, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane)
 
-[![Software Mansion](https://membraneframework.github.io/static/logo/swm_logo_readme.png)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane)
+[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane)
 
 Licensed under the [Apache License, Version 2.0](LICENSE)


### PR DESCRIPTION
<sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>